### PR TITLE
do not use the default pg port

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 VITE_PUBLIC_SERVER='http://localhost:4848'
-ZERO_UPSTREAM_DB="postgresql://user:password@127.0.0.1/zstart"
-ZERO_CVR_DB="postgresql://user:password@127.0.0.1/zstart_cvr"
-ZERO_CHANGE_DB="postgresql://user:password@127.0.0.1/zstart_cdb"
+ZERO_UPSTREAM_DB="postgresql://user:password@127.0.0.1:5430/zstart"
+ZERO_CVR_DB="postgresql://user:password@127.0.0.1:5430/zstart_cvr"
+ZERO_CHANGE_DB="postgresql://user:password@127.0.0.1:5430/zstart_cdb"
 ZERO_JWT_SECRET="secretkey"
 ZERO_REPLICA_FILE="/tmp/zstart_replica.db"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - 5432:5432
+      - 5430:5432
     environment:
       POSTGRES_USER: user
       POSTGRES_DB: postgres


### PR DESCRIPTION
I had `pg.app` running on the default port. Docker started fine but then trying to run zero-cache it tried to connect to the wrong db.

![CleanShot 2024-12-10 at 11 14 17](https://github.com/user-attachments/assets/9135b58a-922d-4773-ba78-e0e745be7183)

There's a good chance other users will have pg running on their machines when trying the quickstart.
