### PR TITLE
make startup portable by moving scripts into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:zero-cache": "zero-cache",
+    "build-schema": "zero-build-schema -p 'src/schema.ts'",
     "docker-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
     "docker-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
     "clean": "source .env && docker volume rm -f docker_zstart_pgdata && rm -rf \"${ZERO_REPLICA_FILE}\"*",


### PR DESCRIPTION
The quickstart flip-flops between using `npm run` and `npx`. This is confusing and:

- `npx` has to be translated to `pnpm exec` for pnpm users.
- `npx` has to be translated to `yarn exec` for `yarn` users

![CleanShot 2024-12-10 at 11 22 23](https://github.com/user-attachments/assets/e66acc5a-0ec6-4e27-85f3-115d6bda1c7b)

![CleanShot 2024-12-10 at 11 21 14](https://github.com/user-attachments/assets/b7ae2ed6-5c07-4a12-a417-ad9d99644ab2)
