### PR TITLE
fix: Action buttons on mobile and better delay option

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,7 +158,7 @@ function App() {
           >
             Remove Messages
           </button>
-          <em>(hold down for multiple)</em>
+          <em>(hold down buttons to repeat)</em>
         </div>
         <div
           style={{


### PR DESCRIPTION
Fix:
1. "add messages" and "remove messages" buttons now work on mobile
2. the above now have an instant action + a INITIAL_HOLD_DELAY from when the hold triggers multiple adds



https://github.com/user-attachments/assets/507fbb3e-15bf-40b6-8ee7-29d3af76b02d


https://github.com/user-attachments/assets/e70cbb83-abfc-438e-ae18-df6271471ec3

