### PR TITLE
fix: load balancer config

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -114,7 +114,12 @@ export default $config({
       },
       loadBalancer: {
         public: true,
-        rules: [{ listen: "80/http", forward: "4848/http" }],
+        ports: [
+          {
+            listen: "80/http",
+            forward: "4848/http",
+          },
+        ],
       },
       transform: {
         target: {


### PR DESCRIPTION
Without this I was getting the error:

You must provide the ports to expose via "loadBalancer.ports"