### PR TITLE
CI: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,15 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 11
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: "pnpm"


### PR DESCRIPTION
Pins \`actions/checkout\`, \`actions/setup-node\`, and \`pnpm/action-setup\` to full-length commit SHAs (v6) instead of mutable tags, for supply-chain safety. \`actions/upload-artifact\` was already SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)