### PR TITLE
Set packages field in pnpm-workspace.yaml to fix Vercel build

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages:
+  - '.'
 allowBuilds:
   '@rocicorp/zero-sqlite3': true
   esbuild: true


### PR DESCRIPTION
## Problem

The Vercel deployment broke after #60 (Zero 1.6 upgrade + pnpm migration). The `pnpm-workspace.yaml` declared `allowBuilds` and `minimumReleaseAgeExclude` but had **no `packages` field**. pnpm treats the presence of the workspace file as a workspace with no member packages, which breaks install/build on Vercel.

## Fix

Declare the root as the sole workspace package:

```yaml
packages:
  - '.'
```

## Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm build` ✅

https://claude.ai/code/session_01MTTajfMM52wTjsYpDVwJbP

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTTajfMM52wTjsYpDVwJbP)_