### PR TITLE
Upgrade devcontainer agents feature to v3

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -5,18 +5,12 @@
       "resolved": "ghcr.io/anthropics/devcontainer-features/claude-code@sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a",
       "integrity": "sha256:cfc2e7d3e9fd3b9b01f8d5cb158508a884c8c0ede2e23ed10f32dea5d4ffe69a"
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "1.1.0",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
-      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
-    },
-    "ghcr.io/rocicorp/devcontainer-features/agents:2": {
-      "version": "2.0.0",
-      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
-      "integrity": "sha256:172905cd57fbc946323644a52d5829415c77ff8c6f217594720966efcba11db6",
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {
+      "version": "3.0.0",
+      "resolved": "ghcr.io/rocicorp/devcontainer-features/agents@sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
+      "integrity": "sha256:cb7bb04455faaab8fa55e5d57656be969f0f59657fee8a3320e61badb025a5a3",
       "dependsOn": [
-        "ghcr.io/anthropics/devcontainer-features/claude-code:1",
-        "ghcr.io/devcontainers/features/github-cli:1"
+        "ghcr.io/anthropics/devcontainer-features/claude-code:1"
       ]
     },
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,19 +16,12 @@
   "workspaceFolder": "/workspaces/hello-zero",
   "shutdownAction": "stopCompose",
   "remoteUser": "node",
-  // Forward the host's GITHUB_TOKEN into the container. Under agents:2, gh
-  // authenticates from this token rather than a persisted login. On the host,
-  // export GITHUB_TOKEN (e.g. from 1Password) before launching VS Code. See
-  // https://github.com/rocicorp/devcontainer-features#gh-auth-via-1password-no-host-side-credentials
-  "remoteEnv": {
-    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
-  },
   "features": {
     // Shared rocicorp features (https://github.com/rocicorp/devcontainer-features):
-    //  - agents: Codex (pinned) + Claude Code + gh; persists the Claude login
-    //    across rebuilds; gh uses the forwarded GITHUB_TOKEN.
+    //  - agents: Codex (pinned) + Claude Code; persists the Claude login
+    //    across rebuilds.
     //  - pnpm: corepack-managed pnpm; removes npm/npx to enforce pnpm.
-    "ghcr.io/rocicorp/devcontainer-features/agents:2": {},
+    "ghcr.io/rocicorp/devcontainer-features/agents:3": {},
     "ghcr.io/rocicorp/devcontainer-features/pnpm:1": {}
   },
   "postCreateCommand": "pnpm install"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      devcontainer-features:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Upgrades the dev container to **v3** of `rocicorp/devcontainer-features/agents`. v3.0.0 is a **breaking** release: it drops the bundled GitHub CLI (`gh`) and 1Password CLI (`op`), so the container no longer injects a `GITHUB_TOKEN` (or 1Password credentials) at shell start. See the [migration note](https://github.com/rocicorp/devcontainer-features#agents).

There is one dev container config in this repo (`.devcontainer/devcontainer.json`); no nested or `src/*` configs exist.

## Changes

- **Pin bump** — `.devcontainer/devcontainer.json`: `ghcr.io/rocicorp/devcontainer-features/agents:2` → `:3`. `pnpm:1` is left as-is; no `codexVersion` option was set, so nothing else changed there.
- **Removed dead wiring** — deleted the `remoteEnv.GITHUB_TOKEN` (`${localEnv:GITHUB_TOKEN}`) passthrough and the `gh`/1Password comments. These existed solely to authenticate the old bundled `gh`, which v3 no longer ships.
- **Lockfile refresh** — `.devcontainer/devcontainer-lock.json` regenerated: `agents` now resolves to the v3 digest (`sha256:cb7bb04455…`) and its `dependsOn` no longer lists `github-cli`, so the standalone `github-cli:1` lock entry is removed. `claude-code:1` and `pnpm:1` are unchanged.
- **Dependabot** — added `.github/dependabot.yml` with a `devcontainers` ecosystem entry (weekly, grouped). The configs live under the root `.devcontainer/`, so `directory: "/"` is correct.

## Risk: risk-free

I grepped the repo for `GITHUB_TOKEN`, `gh`, `op`, `OP_SERVICE_ACCOUNT`, "GitHub CLI", and "1Password" — every hit was inside the devcontainer config/lock itself. Nothing in the repo (no lifecycle command, script, or in-container CI) actually invokes `gh` or `op` inside the container, so the token passthrough was already dead weight. **`github-cli` was not re-added**, because nothing needs it. The `postCreateCommand` is just `pnpm install`, and CI (`.github/workflows/deploy.yml`) runs on GitHub-hosted runners (pnpm + Vercel), unaffected by this change.

## Note on the lockfile

`@devcontainers/cli upgrade` couldn't complete in the sandbox (egress policy blocks the ghcr.io blob host), so the lock was regenerated by resolving the `agents:3` manifest digest directly from the registry. The recorded digest is the registry's authoritative `Docker-Content-Digest`, verified by hashing the manifest bytes — equivalent to what the CLI would write. A clean local `devcontainer upgrade` will be a no-op.